### PR TITLE
Build full stack checks from beat to elasticsearch

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,2 @@
 ---
-extends: default
-
-rules:
-  truthy: disable
+extends: relaxed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Aside from `logstash.yml` we can manage Logstashs pipelines.
 * *logstash_elasticsearch_output*: Enable default pipeline to Elasticsearch (default: `true`)
 * *logstash_beats_input*: Enable default pipeline with `beats` input (default: `true`)
 * *logstash_connector*: Enable default to connect input and output (default: `true`)
-* *logstash_elasticsearch*: Address of Elasticsearch instance for default output (default: `127.0.0.1`)
+* *logstash_elasticsearch*: Address of Elasticsearch instance for default output (default: list of Elasticsearch nodes from `elasticsearch` role or `localhost` when used standalone)
 * *logstash_security*: Enable X-Security (default: `false`)
 
 The following variables only apply if you use this role together with our Elasticsearch and Kibana roles.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ logstash_manage_pipelines: true
 logstash_elasticsearch_output: true
 logstash_beats_input: true
 logstash_connector: true
-logstash_elasticsearch: 127.0.0.1
+#logstash_elasticsearch: 127.0.0.1
 
 # logstash security
 logstash_security: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,6 @@ logstash_manage_pipelines: true
 logstash_elasticsearch_output: true
 logstash_beats_input: true
 logstash_connector: true
-#logstash_elasticsearch: 127.0.0.1
 
 # logstash security
 logstash_security: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,4 @@ logstash_password: password
 elastic_stack_full_stack: false
 elastic_ca_dir: /opt/es-ca
 elastic_initial_passwords: /usr/share/elasticsearch/initial_passwords
+elastic_ca_pass: PleaseChangeMe

--- a/molecule/full_stack/converge.yml
+++ b/molecule/full_stack/converge.yml
@@ -29,3 +29,9 @@
     - name: "Include Logstash"
       include_role:
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+- name: Filebeat
+  hosts: filebeat
+  tasks:
+    - name: "Include Filebeat"
+      include_role:
+        name: filebeat

--- a/molecule/full_stack/converge.yml
+++ b/molecule/full_stack/converge.yml
@@ -23,6 +23,15 @@
     - name: "Include Filebeat"
       include_role:
         name: filebeat
+    - name: "Include Elasticsearch role"
+      include_role:
+        name: elasticsearch
+    - name: "Include Redis"
+      include_role:
+        name: geerlingguy.redis
+    - name: "Include Logstash"
+      include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
     - name: Configure rsyslog
       lineinfile:
         line: "*.* @@localhost:514"
@@ -32,25 +41,3 @@
         name: rsyslog
         state: restarted
       changed_when: false
-- name: Elasticsearch
-  hosts: elasticsearch
-  vars:
-    logstash_enable: true
-    logstash_security: true
-  tasks:
-    - name: "Include Elasticsearch role"
-      include_role:
-        name: elasticsearch
-- name: Logstash
-  hosts: logstash
-  vars:
-    logstash_enable: true
-    logstash_security: true
-  tasks:
-    # temporarily disabled because role is unavailable
-    #- name: "Include Redis"
-    #  include_role:
-    #    name: geerlingguy.redis
-    - name: "Include Logstash"
-      include_role:
-        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/full_stack/converge.yml
+++ b/molecule/full_stack/converge.yml
@@ -34,12 +34,18 @@
       changed_when: false
 - name: Elasticsearch
   hosts: elasticsearch
+  vars:
+    logstash_enable: true
+    logstash_security: true
   tasks:
     - name: "Include Elasticsearch role"
       include_role:
         name: elasticsearch
 - name: Logstash
   hosts: logstash
+  vars:
+    logstash_enable: true
+    logstash_security: true
   tasks:
     # temporarily disabled because role is unavailable
     #- name: "Include Redis"

--- a/molecule/full_stack/converge.yml
+++ b/molecule/full_stack/converge.yml
@@ -20,6 +20,18 @@
       service:
         name: rsyslog
         state: started
+    - name: "Include Filebeat"
+      include_role:
+        name: filebeat
+    - name: Configure rsyslog
+      lineinfile:
+        line: "*.* @@localhost:514"
+        path: /etc/rsyslog.conf
+    - name: Restart rsyslog
+      service:
+        name: rsyslog
+        state: restarted
+      changed_when: false
 - name: Elasticsearch
   hosts: elasticsearch
   tasks:
@@ -36,18 +48,3 @@
     - name: "Include Logstash"
       include_role:
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
-- name: Filebeat
-  hosts: filebeat
-  tasks:
-    - name: "Include Filebeat"
-      include_role:
-        name: filebeat
-    - name: Configure rsyslog
-      lineinfile:
-        line: "*.* @@localhost:514"
-        path: /etc/rsyslog.conf
-    - name: Restart rsyslog
-      service:
-        name: rsyslog
-        state: restarted
-      changed_when: false

--- a/molecule/full_stack/converge.yml
+++ b/molecule/full_stack/converge.yml
@@ -13,6 +13,13 @@
     - name: "Include Elastics repos role"
       include_role:
         name: elastic-repos
+    - name: Install rsyslog
+      package:
+        name: rsyslog
+    - name: Start rsyslog
+      service:
+        name: rsyslog
+        state: started
 - name: Elasticsearch
   hosts: elasticsearch
   tasks:
@@ -35,3 +42,11 @@
     - name: "Include Filebeat"
       include_role:
         name: filebeat
+    - name: Configure rsyslog
+      lineinfile:
+        line: "*.* @@localhost:514"
+        path: /etc/rsyslog.conf
+    - name: Restart rsyslog
+      service:
+        name: rsyslog
+        state: restarted

--- a/molecule/full_stack/converge.yml
+++ b/molecule/full_stack/converge.yml
@@ -50,3 +50,4 @@
       service:
         name: rsyslog
         state: restarted
+      changed_when: false

--- a/molecule/full_stack/molecule.yml
+++ b/molecule/full_stack/molecule.yml
@@ -6,7 +6,9 @@ driver:
 platforms:
   - name: logstash-full
     groups:
+      - elasticsearch
       - logstash
+      - filebeat
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:

--- a/molecule/full_stack/molecule.yml
+++ b/molecule/full_stack/molecule.yml
@@ -4,27 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: logstash-full-logstash
+  - name: logstash-full
     groups:
       - logstash
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-  - name: logstash-full-elasticsearch
-    groups:
-      - elasticsearch
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-  - name: logstash-full-filebeat
-    groups:
-      - filebeat
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:

--- a/molecule/full_stack/molecule.yml
+++ b/molecule/full_stack/molecule.yml
@@ -22,6 +22,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+  - name: logstash-full-filebeat
+    groups:
+      - filebeat
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
 verifier:

--- a/molecule/full_stack/requirements.yml
+++ b/molecule/full_stack/requirements.yml
@@ -5,4 +5,7 @@
 - name: elasticsearch
   src: https://github.com/widhalmt/ansible-role-elasticsearch.git
   scm: git
+- name: filebeat
+  src: https://github.com/widhalmt/ansible-role-filebeat.git
+  scm: git
 - src: geerlingguy.redis

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -27,11 +27,15 @@
       tail -1
     register: logstash_count
     when: "'elasticsearch' in group_names"
+  - name: Show full output
+    debug:
+      var: logstash_count
+    when: "'elasticsearch' in group_names"
   - name: Fail when logstash is empty
     fail:
       msg: "Logstash Index is empty"
     when: "'elasticsearch' in group_names and logstash_count.stdout == 0"
   - name: Show number of received events
     debug:
-      msg: "Elasticsearch received {{ logstash_count.stdout }} so far"
+      msg: "Elasticsearch received {{ logstash_count.stdout }} events so far"
     when: "'elasticsearch' in group_names"

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -19,11 +19,12 @@
     when: "'elasticsearch' in group_names"
   - name: Query for Logstasch indices
     shell: >
-      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
-      grep logstash |
-      awk {' print $7 '} |
-      sort -n |
-      tail -1
+      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices
+  #    curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
+  #    grep logstash |
+  #    awk {' print $7 '} |
+  #    sort -n |
+  #    tail -1
     register: logstash_count
     when: "'elasticsearch' in group_names"
   - name: Show full output

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -34,3 +34,4 @@
   - name: Show number of received events
     debug:
       msg: "Elasticsearch received {{ logstash_count.stdout }} so far"
+    when: "'elasticsearch' in group_names"

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -4,9 +4,9 @@
 - name: Check if Logstash configuration does what it should
   hosts: all
   tasks:
-#  - name: Give some time for tools to connect
-#    wait_for:
-#      timeout: 300
+  - name: Give some time for tools to connect
+    wait_for:
+      timeout: 120
   - name: Run syntax check
     command: "/usr/share/logstash/bin/logstash --path.settings=/etc/logstash -t"
     when: "'logstash' in group_names"

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -18,9 +18,8 @@
     register: elastic_pass
     when: "'elasticsearch' in group_names"
   - name: Query for Logstasch indices
-    shell: |
-      curl -ks -uelastic:{{ elastic_pass.stdout }}
-      https://localhost:9200/_cat/indices |
+    shell: >
+      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
       grep logstash |
       awk {' print $7 '} |
       sort -n |

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -30,7 +30,7 @@
   - name: Fail when logstash is empty
     fail:
       msg: "Logstash Index is empty"
-    when: elasticsearch in group_names and logstash_count.stdout == 0
+    when: "'elasticsearch' in group_names and logstash_count.stdout == 0"
   - name: Show number of received events
     debug:
       msg: "Elasticsearch received {{ logstash_count.stdout }} so far"

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -4,6 +4,9 @@
 - name: Check if Logstash configuration does what it should
   hosts: all
   tasks:
+  - name: Give some time for tools to connect
+    wait_for:
+      timeout: 300
   - name: Run syntax check
     command: "/usr/share/logstash/bin/logstash --path.settings=/etc/logstash -t"
     when: "'logstash' in group_names"

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -4,9 +4,9 @@
 - name: Check if Logstash configuration does what it should
   hosts: all
   tasks:
-  - name: Give some time for tools to connect
-    wait_for:
-      timeout: 300
+#  - name: Give some time for tools to connect
+#    wait_for:
+#      timeout: 300
   - name: Run syntax check
     command: "/usr/share/logstash/bin/logstash --path.settings=/etc/logstash -t"
     when: "'logstash' in group_names"
@@ -22,12 +22,11 @@
     when: "'elasticsearch' in group_names"
   - name: Query for Logstasch indices
     shell: >
-      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices
-  #    curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
-  #    grep logstash |
-  #    awk {' print $7 '} |
-  #    sort -n |
-  #    tail -1
+      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
+      grep logstash |
+      awk {' print $7 '} |
+      sort -n |
+      tail -1
     register: logstash_count
     when: "'elasticsearch' in group_names"
   - name: Show full output

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -11,3 +11,23 @@
     wait_for:
       port: 5044
     when: "'logstash' in group_names"
+  - name: Get elastic password
+    shell: |
+      grep "PASSWORD elastic " /usr/share/elasticsearch/initial_passwords |
+      awk {' print $4 '}
+    register: elastic_pass
+    when: "'elasticsearch' in group_names"
+  - name: Query for Logstasch indices
+    shell: |
+      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
+      grep logstash |
+      awk {' print $7 '} |
+      sort -n |
+      tail -1
+    register: logstash_count
+    when: "'elasticsearch' in group_names"
+  - name: Fail when logstash is empty
+    fail:
+      msg: Logstash Index is empty
+    when: logstash_count.stdout == 0
+    when: "'elasticsearch' in group_names"

--- a/molecule/full_stack/verify.yml
+++ b/molecule/full_stack/verify.yml
@@ -19,7 +19,8 @@
     when: "'elasticsearch' in group_names"
   - name: Query for Logstasch indices
     shell: |
-      curl -ks -uelastic:{{ elastic_pass.stdout }} https://localhost:9200/_cat/indices |
+      curl -ks -uelastic:{{ elastic_pass.stdout }}
+      https://localhost:9200/_cat/indices |
       grep logstash |
       awk {' print $7 '} |
       sort -n |
@@ -28,6 +29,8 @@
     when: "'elasticsearch' in group_names"
   - name: Fail when logstash is empty
     fail:
-      msg: Logstash Index is empty
-    when: logstash_count.stdout == 0
-    when: "'elasticsearch' in group_names"
+      msg: "Logstash Index is empty"
+    when: elasticsearch in group_names and logstash_count.stdout == 0
+  - name: Show number of received events
+    debug:
+      msg: "Elasticsearch received {{ logstash_count.stdout }} so far"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+
+- name: Set Elasticsearch hosts if used with other roles
+  set_fact:
+    logstash_elasticsearch: "{{ groups['elasticsearch'] }}"
+  when: logstash_elasticsearch is undefined and groups['elasticsearch'] is defined
+
+- name: Set Elasticsearch hosts to localhost if no other information is available
+  set_fact:
+    logstash_elasticsearch:
+      - localhost
+  when: logstash_elasticsearch is undefined and groups['elasticsearch'] is undefined
+
+
 - name: Ensure Logstash is installed
   package:
     name: logstash

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -1,6 +1,6 @@
 output {
   elasticsearch {
-    hosts => [ "{{ logstash_elasticsearch }}"]
+    hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
 {% if elastic_stack_full_stack | bool and logstash_security | bool %}
     keystore => "/etc/logstash/certs/cert.p12"
     keystore_password => ""


### PR DESCRIPTION
fixes #32

We need to configure rsyslog to send events to filebeat to get testmessages. We should do this is as a post task in the `converge.yml` playbook and maybe wait some time.

Linter found something, too.