### PR TITLE
Allow for usage of OSS variant of Logstash

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 skip_list:
-  - '303'
-  - '306'
+  - 'command-instead-of-module'
+  - 'risky-shell-pipe'
+  - 'role-name'

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,7 +16,7 @@ jobs:
       # max-parallel: 4
       matrix:
         distro: [centos7, debian10]
-        scenario: [default, run_logstash, full_stack]
+        scenario: [default, run_logstash, full_stack, full_stack-oss]
 
     steps:
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ It can optionally configure two types of Logstash pipelines:
 * Pipeline configuration managed in an external git repository
 * A default pipeline which will read from different Redis keys and write into Elasticsearch
 
+It will work with the standard Elastic Stack packages and Elastics OSS variant.
+
 Requirements
 ------------
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Aside from `logstash.yml` we can manage Logstashs pipelines.
 * *logstash_elasticsearch*: Address of Elasticsearch instance for default output (default: list of Elasticsearch nodes from `elasticsearch` role or `localhost` when used standalone)
 * *logstash_security*: Enable X-Security (default: `false`)
 
+These variables are identical over all our elastic related roles, hence the different naming scheme.
+
+*elastic_release*: Major release version of Elastic stack to configure. (default: `7`)
+*elastic_variant*: Variant of the stack to install. Valid values: `elastic` or `oss`. (default: `elastic`)
+
 The following variables only apply if you use this role together with our Elasticsearch and Kibana roles.
 
 * *elastic_stack_full_stack*: Use `ansible-role-elasticsearch` as well (default: `false`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,8 @@ elastic_stack_full_stack: false
 elastic_ca_dir: /opt/es-ca
 elastic_initial_passwords: /usr/share/elasticsearch/initial_passwords
 elastic_ca_pass: PleaseChangeMe
+
+# "global" variables for all roles
+
+elastic_release: 7
+elastic_variant: elastic

--- a/molecule/full_stack-oss/INSTALL.rst
+++ b/molecule/full_stack-oss/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/full_stack-oss/converge.yml
+++ b/molecule/full_stack-oss/converge.yml
@@ -1,0 +1,51 @@
+---
+# The workaround for arbitrarily named role directory is important because the
+# git repo has one name and the role within it another
+# Found at:
+# https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
+#
+# Currently security is not implemented with OSS. We leave the variable set
+# to check for handling of misconfiguration (and be prepared for upcoming
+# implementations)
+# But we need to deactivate security in Elasticsearch to not lock out
+# Logstash
+- name: Converge
+  hosts: all
+  vars:
+    logstash_enable: true
+    logstash_security: true
+    elasticsearch_security: false
+    elastic_stack_full_stack: true
+    elastic_variant: oss
+  tasks:
+    - name: "Include Elastics repos role"
+      include_role:
+        name: elastic-repos
+    - name: Install rsyslog
+      package:
+        name: rsyslog
+    - name: Start rsyslog
+      service:
+        name: rsyslog
+        state: started
+    - name: "Include Filebeat"
+      include_role:
+        name: filebeat
+    - name: "Include Elasticsearch role"
+      include_role:
+        name: elasticsearch
+    - name: "Include Redis"
+      include_role:
+        name: geerlingguy.redis
+    - name: "Include Logstash"
+      include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - name: Configure rsyslog
+      lineinfile:
+        line: "*.* @@localhost:514"
+        path: /etc/rsyslog.conf
+    - name: Restart rsyslog
+      service:
+        name: rsyslog
+        state: restarted
+      changed_when: false

--- a/molecule/full_stack-oss/molecule.yml
+++ b/molecule/full_stack-oss/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: logstash-full-oss
+    groups:
+      - elasticsearch
+      - logstash
+      - filebeat
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/full_stack-oss/prepare.yml
+++ b/molecule/full_stack-oss/prepare.yml
@@ -1,0 +1,14 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install git
+      package:
+        name: git
+    - name: Install packages for Debian
+      package:
+        name:
+          - gpg
+          - procps
+          - curl
+      when: ansible_os_family == "Debian"

--- a/molecule/full_stack-oss/requirements.yml
+++ b/molecule/full_stack-oss/requirements.yml
@@ -1,0 +1,11 @@
+---
+- name: elastic-repos
+  src: https://github.com/widhalmt/ansible-role-elastic-repos
+  scm: git
+- name: elasticsearch
+  src: https://github.com/widhalmt/ansible-role-elasticsearch.git
+  scm: git
+- name: filebeat
+  src: https://github.com/widhalmt/ansible-role-filebeat.git
+  scm: git
+- src: geerlingguy.redis

--- a/molecule/full_stack-oss/verify.yml
+++ b/molecule/full_stack-oss/verify.yml
@@ -1,0 +1,37 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Check if Logstash configuration does what it should
+  hosts: all
+  tasks:
+  - name: Give some time for tools to connect
+    wait_for:
+      timeout: 120
+  - name: Run syntax check
+    command: "/usr/share/logstash/bin/logstash --path.settings=/etc/logstash -t"
+    when: "'logstash' in group_names"
+  - name: Check for open port 5044/tcp
+    wait_for:
+      port: 5044
+    when: "'logstash' in group_names"
+  - name: Query for Logstasch indices
+    shell: >
+      curl -s http://localhost:9200/_cat/indices |
+      grep logstash |
+      awk {' print $7 '} |
+      sort -n |
+      tail -1
+    register: logstash_count
+    when: "'elasticsearch' in group_names"
+  - name: Show full output
+    debug:
+      var: logstash_count
+    when: "'elasticsearch' in group_names"
+  - name: Fail when logstash is empty
+    fail:
+      msg: "Logstash Index is empty"
+    when: "'elasticsearch' in group_names and logstash_count.stdout == 0"
+  - name: Show number of received events
+    debug:
+      msg: "Elasticsearch received {{ logstash_count.stdout }} events so far"
+    when: "'elasticsearch' in group_names"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,18 +3,28 @@
 - name: Set Elasticsearch hosts if used with other roles
   set_fact:
     logstash_elasticsearch: "{{ groups['elasticsearch'] }}"
-  when: logstash_elasticsearch is undefined and groups['elasticsearch'] is defined
+  when:
+    - logstash_elasticsearch is undefined
+    - groups['elasticsearch'] is defined
 
-- name: Set Elasticsearch hosts to localhost if no other information is available
+- name: Set Elasticsearch hosts to localhost if no other information available
   set_fact:
     logstash_elasticsearch:
       - localhost
-  when: logstash_elasticsearch is undefined and groups['elasticsearch'] is undefined
+  when:
+    - logstash_elasticsearch is undefined
+    - groups['elasticsearch'] is undefined
 
 
 - name: Ensure Logstash is installed
   package:
     name: logstash
+  when: elastic_variant == "elastic"
+
+- name: Ensure Logstash OSS is installed
+  package:
+    name: logstash-oss
+  when: elastic_variant == "oss"
 
 - name: Configure Logstash
   template:
@@ -142,7 +152,10 @@
   when: logstash_manage_pipelines | bool
 
 - import_tasks: logstash-security.yml
-  when: elastic_stack_full_stack | bool and logstash_security | bool
+  when:
+    - elastic_stack_full_stack | bool
+    - logstash_security | bool
+    - elastic_variant == "elastic"
   tags:
     - security
 

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -1,7 +1,7 @@
 output {
   elasticsearch {
     hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
-{% if elastic_stack_full_stack | bool and logstash_security | bool %}
+{% if elastic_stack_full_stack | bool and logstash_security | bool and elastic_variant == "elastic" %}
     keystore => "/etc/logstash/certs/cert.p12"
     keystore_password => ""
     cacert => "/etc/logstash/certs/ca.crt"


### PR DESCRIPTION
* Use "global" variable `elastic_variant`
* Install fitting packages
* Disable features not available in OSS variant

Fixes #38