### PR TITLE
Convert keystore for newer Logstash versions

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,3 +11,12 @@
     name: logstash
     state: restarted
   when: not logstash_config_autoreload and logstash_enable | bool
+
+- name: Reconvert keystore
+  shell: >
+    openssl pkcs12
+    -in "/etc/logstash/certs/cert.p12"
+    -nodes |
+    openssl pkcs12
+    -export
+    -out "/etc/logstash/certs/keystore.pfx"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,16 @@
   shell: >
     openssl pkcs12
     -in "/etc/logstash/certs/cert.p12"
+    -password pass:""
     -nodes |
     openssl pkcs12
     -export
+    -password pass:""
     -out "/etc/logstash/certs/keystore.pfx"
+
+- name: Reset permissions on keystore
+  file:
+    path: /etc/logstash/certs/keystore.pfx
+    owner: root
+    group: logstash
+    mode: 0660

--- a/tasks/logstash-security.yml
+++ b/tasks/logstash-security.yml
@@ -50,6 +50,7 @@
     mode: 0640
   notify:
     - Reconvert keystore
+    - Reset permissions on keystore
     - Restart Logstash
   tags:
     - certificates
@@ -58,13 +59,21 @@
   shell: >
     openssl pkcs12
     -in "/etc/logstash/certs/cert.p12"
+    -password pass:""
     -nodes |
     openssl pkcs12
     -export
+    -password pass:""
     -out "/etc/logstash/certs/keystore.pfx"
   args:
     creates: "/etc/logstash/certs/keystore.pfx"
 
+- name: Set permissions on keystore
+  file:
+    path: /etc/logstash/certs/keystore.pfx
+    owner: root
+    group: logstash
+    mode: 0660
 
 - name: Fetch ca certificate from ca host to master
   fetch:

--- a/tasks/logstash-security.yml
+++ b/tasks/logstash-security.yml
@@ -49,9 +49,22 @@
     group: logstash
     mode: 0640
   notify:
+    - Reconvert keystore
     - Restart Logstash
   tags:
     - certificates
+
+- name: Convert keystore
+  shell: >
+    openssl pkcs12
+    -in "/etc/logstash/certs/cert.p12"
+    -nodes |
+    openssl pkcs12
+    -export
+    -out "/etc/logstash/certs/keystore.pfx"
+  args:
+    creates: "/etc/logstash/certs/keystore.pfx"
+
 
 - name: Fetch ca certificate from ca host to master
   fetch:

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -2,7 +2,7 @@ output {
   elasticsearch {
     hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
 {% if elastic_stack_full_stack | bool and logstash_security | bool and elastic_variant == "elastic" %}
-    keystore => "/etc/logstash/certs/cert.p12"
+    keystore => "/etc/logstash/certs/keystore.pdx"
     keystore_password => ""
     cacert => "/etc/logstash/certs/ca.crt"
     ssl => true

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -2,7 +2,7 @@ output {
   elasticsearch {
     hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
 {% if elastic_stack_full_stack | bool and logstash_security | bool and elastic_variant == "elastic" %}
-    keystore => "/etc/logstash/certs/keystore.pdx"
+    keystore => "/etc/logstash/certs/keystore.pfx"
     keystore_password => ""
     cacert => "/etc/logstash/certs/ca.crt"
     ssl => true


### PR DESCRIPTION
I'll call this a draft because it was laying around for some time unnoticed. Needs to be rechecked.

fixes #69 