### PR TITLE
Optionally enable TLS for beats input

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,4 @@ skip_list:
   - 'command-instead-of-module'
   - 'risky-shell-pipe'
   - 'role-name'
+  - 'fqcn-builtins'

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,4 @@ skip_list:
   - 'risky-shell-pipe'
   - 'role-name'
   - 'fqcn-builtins'
+  - 'yaml'

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Lint code.
         run: |
+          ls -lah
           yamllint .
           ansible-lint .
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2
-        with:
-          path: 'bdpa.logstash'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2
@@ -27,7 +25,6 @@ jobs:
 
       - name: Lint code.
         run: |
-          ls -lah
           yamllint .
           ansible-lint .
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Role Variables
 * *logstash_config_backup*: Keep backups of all changed configuration (default: `no`)
 * *logstash_manage_yaml*: Manage and overwrite `logstash.yml` (default: `true`)
 * *logstash_plugins*: List of plugins to install (default: none)
+* *logstash_certs_dir*: Path to certificates. Will be used to build paths of several files. (Default: `/etc/logstash/certs`)
 
 If `logstash.yml` is managed, the following settings apply.
 
@@ -46,6 +47,8 @@ Aside from `logstash.yml` we can manage Logstashs pipelines.
 * *logstash_elasticsearch_output*: Enable default pipeline to Elasticsearch (default: `true`)
 * *logstash_beats_input*: Enable default pipeline with `beats` input (default: `true`)
 * *logstash_beats_input_congestion*: Optional congestion threshold for the beats input pipeline
+* *logstash_beats_tls*: Activate TLS for the beats input pipeline (default: `false` but `true` with full stack setup)
+* *logstash_tls_key_passphrase*: Passphrase for Logstash certificates (default: `ChangeMe`)
 * *logstash_connector*: Create pipelines to connect git managed pipelines. (default: `true`)
 * *logstash_connector_pipelines*: Definition of connector pipelines. See docs/connector-pipelines.md for details
 * *logstash_elasticsearch*: Address of Elasticsearch instance for default output (default: list of Elasticsearch nodes from `elasticsearch` role or `localhost` when used standalone)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,10 @@ logstash_connector_pipelines:
       - name: default
         key: forwarder
 
+logstash_beats_tls: false
+logstash_tls_key_passphrase: ChangeMe
+logstash_certs_dir: /etc/logstash/certs
+
 logstash_legacy_monitoring: true
 
 # elastic full stack configuration

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,17 +15,17 @@
 - name: Reconvert keystore
   shell: >
     openssl pkcs12
-    -in "/etc/logstash/certs/cert.p12"
-    -password pass:""
+    -in "{{ logstash_certs_dir }}/{{ inventory_hostname }}.p12"
+    -password pass:"{{ logstash_tls_key_passphrase }}"
     -nodes |
     openssl pkcs12
     -export
-    -password pass:""
-    -out "/etc/logstash/certs/keystore.pfx"
+    -password pass:"{{ logstash_tls_key_passphrase }}"
+    -out "{{ logstash_certs_dir }}/keystore.pfx"
 
 - name: Reset permissions on keystore
   file:
-    path: /etc/logstash/certs/keystore.pfx
+    path: "{{ logstash_certs_dir }}/keystore.pfx"
     owner: root
     group: logstash
     mode: 0660

--- a/tasks/logstash-security.yml
+++ b/tasks/logstash-security.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Set common password for common certificates
+  set_fact:
+    logstash_tls_key_passphrase: "{{ elastic_cert_pass }}"
+  when: elastic_cert_pass is defined
+
 - name: Set elasticsearch_ca variable if not already done by user
   set_fact:
     elasticsearch_ca: "{{ groups['elasticsearch'][0] }}"
@@ -16,7 +22,7 @@
     --name {{ ansible_hostname }}
     --ip {{ ansible_default_ipv4.address }}
     --dns {{ ansible_hostname }},{{ ansible_fqdn }}
-    --pass ""
+    --pass "{{ logstash_tls_key_passphrase }}"
     --out {{ elastic_ca_dir }}/{{ ansible_hostname }}.p12
   delegate_to: "{{ elasticsearch_ca }}"
   args:
@@ -46,7 +52,7 @@
 - name: Copy the certificate to actual node
   copy:
     src: "/tmp/{{ ansible_hostname }}.p12"
-    dest: "/etc/logstash/certs/cert.p12"
+    dest: "{{ logstash_certs_dir }}/{{ inventory_hostname }}.p12"
     owner: root
     group: logstash
     mode: 0640
@@ -60,19 +66,93 @@
 - name: Convert keystore
   shell: >
     openssl pkcs12
-    -in "/etc/logstash/certs/cert.p12"
-    -password pass:""
+    -in "{{ logstash_certs_dir }}/{{ inventory_hostname }}.p12"
+    -password pass:"{{ logstash_tls_key_passphrase }}"
     -nodes |
     openssl pkcs12
     -export
-    -password pass:""
-    -out "/etc/logstash/certs/keystore.pfx"
+    -password pass:"{{ logstash_tls_key_passphrase }}"
+    -out "{{ logstash_certs_dir }}/keystore.pfx"
   args:
-    creates: "/etc/logstash/certs/keystore.pfx"
+    creates: "{{ logstash_certs_dir }}/keystore.pfx"
+
+- name: create individual PEM certificates for Logstash
+  command: >
+    /usr/share/elasticsearch/bin/elasticsearch-certutil cert
+    --ca {{ elastic_ca_dir }}/elastic-stack-ca.p12
+    --ca-pass {{ elastic_ca_pass }}
+    --name {{ ansible_hostname }}
+    --ip {{ ansible_default_ipv4.address }}
+    --dns {{ ansible_hostname }},{{ ansible_fqdn }}
+    --pass {{ logstash_tls_key_passphrase }}
+    --pem
+    --out {{ elastic_ca_dir }}/{{ ansible_hostname }}.zip
+  delegate_to: "{{ elasticsearch_ca }}"
+  args:
+    creates: "{{ elastic_ca_dir }}/{{ ansible_hostname }}.zip"
+
+- name: Fetch certificate from ca host to master
+  fetch:
+    src: "{{ elastic_ca_dir }}/{{ ansible_hostname }}.zip"
+    dest: "/tmp/{{ ansible_hostname }}.zip"
+    flat: yes
+  delegate_to: "{{ elasticsearch_ca }}"
+  tags:
+    - certificates
+
+- name: Copy the certificate to actual node
+  unarchive:
+    src: "/tmp/{{ ansible_hostname }}.zip"
+    dest: "{{ logstash_certs_dir }}/"
+    owner: root
+    group: logstash
+    mode: 0640
+  tags:
+    - certificates
+
+- name: Copy certificate locally
+  copy:
+    src: "{{ logstash_certs_dir }}/{{ ansible_hostname }}/{{ ansible_hostname }}.crt"
+    dest: "{{ logstash_certs_dir }}/{{ inventory_hostname }}-server.crt"
+    owner: root
+    group: logstash
+    mode: 0640
+    remote_src: true
+  tags:
+    - certificates
+
+- name: Copy key locally
+  copy:
+    src: "{{ logstash_certs_dir }}/{{ ansible_hostname }}/{{ ansible_hostname }}.key"
+    dest: "{{ logstash_certs_dir }}/{{ inventory_hostname }}.key"
+    owner: root
+    group: root
+    mode: 0640
+    remote_src: true
+  tags:
+    - certificates
+
+- name: Create Logstash compatible key
+  command: >
+    openssl pkcs8
+    -in {{ logstash_certs_dir }}/{{ inventory_hostname }}.key
+    -topk8
+    -passin pass:{{ logstash_tls_key_passphrase }}
+    -out {{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key
+    -passout pass:{{ logstash_tls_key_passphrase }}
+  args:
+    creates: "{{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key"
+
+- name: Set permissions on Logstash key
+  file:
+    path: "{{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key"
+    owner: root
+    group: logstash
+    mode: 0660
 
 - name: Set permissions on keystore
   file:
-    path: /etc/logstash/certs/keystore.pfx
+    path: "{{ logstash_certs_dir }}/keystore.pfx"
     owner: root
     group: logstash
     mode: 0660

--- a/tasks/logstash-security.yml
+++ b/tasks/logstash-security.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Install unzip for certificate handling
+  package:
+    name: unzip
+
 - name: Set common password for common certificates
   set_fact:
     logstash_tls_key_passphrase: "{{ elastic_cert_pass }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,24 @@
 ---
 
-- name: Set Elasticsearch hosts if used with other roles
-  set_fact:
-    logstash_elasticsearch: "{{ groups['elasticsearch'] }}"
+- name: Prepare for whole stack roles if used
+  block:
+
+  - name: Set Elasticsearch hosts if used with other roles
+    set_fact:
+      logstash_elasticsearch: "{{ groups['elasticsearch'] }}"
+    when:
+      - logstash_elasticsearch is undefined
+      - groups['elasticsearch'] is defined
+    tags:
+      - configuration
+      - logstash_configuration
+
+  - name: Activate TLS for Beats for full stack
+    set_fact:
+      logstash_beats_tls: true
+
   when:
-    - logstash_elasticsearch is undefined
-    - groups['elasticsearch'] is defined
-  tags:
-    - configuration
-    - logstash_configuration
+    - elastic_stack_full_stack | bool
 
 - name: Set Elasticsearch hosts to localhost if no other information available
   set_fact:

--- a/templates/beats-input.conf.j2
+++ b/templates/beats-input.conf.j2
@@ -1,5 +1,15 @@
 input {
   beats {
     port => 5044
+{% if logstash_beats_tls | bool %}
+    ssl => true
+    ssl_certificate => "{{ logstash_certs_dir }}/{{ inventory_hostname }}-server.crt"
+    ssl_key => "{{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key"
+    ssl_verify_mode => force_peer
+    ssl_certificate_authorities => ["{{ logstash_certs_dir }}/ca.crt"]
+    ssl_peer_metadata => false
+    ssl_key_passphrase => "{{ logstash_tls_key_passphrase }}"
+{% endif %}
+
   }
 }

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -2,9 +2,9 @@ output {
   elasticsearch {
     hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]
 {% if elastic_stack_full_stack | bool and logstash_security | bool and elastic_variant == "elastic" %}
-    keystore => "/etc/logstash/certs/keystore.pfx"
-    keystore_password => ""
-    cacert => "/etc/logstash/certs/ca.crt"
+    keystore => "{{ logstash_certs_dir }}/keystore.pfx"
+    keystore_password => "{{ logstash_tls_key_passphrase }}"
+    cacert => "{{ logstash_certs_dir }}/ca.crt"
     ssl => true
     user => "{{ logstash_user }}"
     password => "{{ logstash_password }}"

--- a/templates/logstash.yml.j2
+++ b/templates/logstash.yml.j2
@@ -18,7 +18,7 @@ xpack.monitoring.enabled: true
 xpack.monitoring.elasticsearch.hosts: [ {% for host in logstash_elasticsearch %}"https://{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %} ]
 xpack.monitoring.elasticsearch.username: elastic
 xpack.monitoring.elasticsearch.password: {{ elastic_password_logstash.stdout }}
-xpack.monitoring.elasticsearch.ssl.certificate_authority: "/etc/logstash/certs/ca.crt"
+xpack.monitoring.elasticsearch.ssl.certificate_authority: "{{ logstash_certs_dir }}/ca.crt"
 xpack.monitoring.elasticsearch.sniffing: true
 xpack.monitoring.collection.pipeline.details.enabled: true
 {% endif %}


### PR DESCRIPTION
fixes #92 

This enables TLS for beats optionally. And includes minor fixes that were needed for this change to work.