### PR TITLE
Add optional identifier to pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ The following variables configure Log4j for Logstash. All default to `true` as t
 * *logstash_logging_slow_console*: Log slowlog to console - syslog when run via systemd
 * *logstash_logging_slow_file*: Log slowlog to logfile
 
+The following variables configure extra fields in your events that help with identifying which pipelines have been passed or which pipeline is used how much.
+
+* *logstash_pipeline_identifier*: Activate this feature (default: `true`)
+* *logstash_pipeline_identifier_field_name*: Name of the field to add (default: `"[netways][pipeline]")
+
 The following variables are identical over all our elastic related roles, hence the different naming scheme.
 
 *elastic_release*: Major release version of Elastic stack to configure. (default: `7`)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following variables configure Log4j for Logstash. All default to `true` as t
 The following variables configure extra fields in your events that help with identifying which pipelines have been passed or which pipeline is used how much.
 
 * *logstash_pipeline_identifier*: Activate this feature (default: `true`)
-* *logstash_pipeline_identifier_field_name*: Name of the field to add (default: `"[netways][pipeline]")
+* *logstash_pipeline_identifier_field_name*: Name of the field to add (default: `"[netways][pipeline]"`)
 * *logstash_pipeline_identifier_defaults*: Use identifiers in default pipelines, too (default: `false`) This could lead to the defaults dominating all statistics with virtually no value, but if you want to see, them, you can.
 
 The following variables are identical over all our elastic related roles, hence the different naming scheme.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following variables configure extra fields in your events that help with ide
 
 * *logstash_pipeline_identifier*: Activate this feature (default: `true`)
 * *logstash_pipeline_identifier_field_name*: Name of the field to add (default: `"[netways][pipeline]")
+* *logstash_pipeline_identifier_defaults*: Use identifiers in default pipelines, too (default: `false`) This could lead to the defaults dominating all statistics with virtually no value, but if you want to see, them, you can.
 
 The following variables are identical over all our elastic related roles, hence the different naming scheme.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,9 @@ logstash_logging_file: true
 logstash_logging_slow_console: true
 logstash_logging_slow_file: true
 
+logstash_pipeline_identifier: true
+logstash_pipeline_identifier_field_name: "[netways][pipeline]"
+
 # elastic full stack configuration
 elastic_stack_full_stack: false
 elastic_ca_dir: /opt/es-ca

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ logstash_logging_slow_file: true
 
 logstash_pipeline_identifier: true
 logstash_pipeline_identifier_field_name: "[netways][pipeline]"
+logstash_pipeline_identifier_defaults: false
 
 # elastic full stack configuration
 elastic_stack_full_stack: false

--- a/molecule/pipelines/converge.yml
+++ b/molecule/pipelines/converge.yml
@@ -26,6 +26,8 @@
         output:
           - name: forwarder
             key: forwarder
+    logstash_pipeline_identifier_field_name: "[mytest][pipelines]"
+    logstash_pipeline_identifier_defaults: true
   tasks:
     - name: "Include Elastics repos role"
       include_role:

--- a/molecule/specific_version/converge.yml
+++ b/molecule/specific_version/converge.yml
@@ -9,6 +9,7 @@
     logstash_manage_logging: true
     logstash_logging_console: false
     logstash_logging_slow_file: false
+    logstash_pipeline_identifier: false
   tasks:
 
   - name: Set Logstash version on RedHat

--- a/templates/connector.conf.j2
+++ b/templates/connector.conf.j2
@@ -11,6 +11,16 @@ input {
 
 }
 
+{% if logstash_pipeline_identifier | bool %}
+filter {
+  mutate {
+    add_field => {
+      "{{ logstash_pipeline_identifier_field_name }}" => "{{ item.name }}"
+    }
+  }
+}
+
+{% endif %}
 output {
 {% for output in item.output %}
 

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -1,3 +1,13 @@
+{% if logstash_pipeline_identifier | bool %}
+filter {
+  mutate {
+    add_field => {
+      "{{ logstash_pipeline_identifier_field_name }}" => "ansible-forwarder"
+    }
+  }
+}
+
+{% endif %}
 output {
   elasticsearch {
     hosts => [ {% for host in logstash_elasticsearch %}"{{ host }}:9200"{% if not loop.last %},{% endif %}{% endfor %}]

--- a/templates/elasticsearch-output.conf.j2
+++ b/templates/elasticsearch-output.conf.j2
@@ -1,4 +1,4 @@
-{% if logstash_pipeline_identifier | bool %}
+{% if logstash_pipeline_identifier | bool and logstash_pipeline_identifier_defaults | bool %}
 filter {
   mutate {
     add_field => {

--- a/templates/redis-output.conf.j2
+++ b/templates/redis-output.conf.j2
@@ -1,4 +1,4 @@
-{% if logstash_pipeline_identifier | bool %}
+{% if logstash_pipeline_identifier | bool and logstash_pipeline_identifier_defaults | bool %}
 filter {
   mutate {
     add_field => {

--- a/templates/redis-output.conf.j2
+++ b/templates/redis-output.conf.j2
@@ -1,3 +1,13 @@
+{% if logstash_pipeline_identifier | bool %}
+filter {
+  mutate {
+    add_field => {
+      "{{ logstash_pipeline_identifier_field_name }}" => "ansible-input"
+    }
+  }
+}
+
+{% endif %}
 output {
   redis {
     host => "localhost"

--- a/templates/simple-output.conf.j2
+++ b/templates/simple-output.conf.j2
@@ -1,3 +1,13 @@
+{% if logstash_pipeline_identifier | bool %}
+filter {
+  mutate {
+    add_field => {
+      "{{ logstash_pipeline_identifier_field_name }}" => "{{ item.name }}"
+    }
+  }
+}
+
+{% endif %}
 output {
 {% for output in item.output %}
 


### PR DESCRIPTION
fixes #129

This will add, optionally, an extra field that will fill with information about which pipelines are passed. It can be used to help with debugging and statistics.

What do you think, @afeefghannam89 and @pdolinic ?