### PR TITLE
Fix broken keys on some systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Aside from `logstash.yml` we can manage Logstashs pipelines.
 * *logstash_beats_input*: Enable default pipeline with `beats` input (default: `true`)
 * *logstash_beats_input_congestion*: Optional congestion threshold for the beats input pipeline
 * *logstash_beats_tls*: Activate TLS for the beats input pipeline (default: none but `true` with full stack setup if not set)
+* *logstash_beats_tls_encryptkey*: Enable encryption of key for beats input - disabling used as a workaround on certain hosts (default: true)
 * *logstash_tls_key_passphrase*: Passphrase for Logstash certificates (default: `ChangeMe`)
 * *logstash_connector*: Create pipelines to connect git managed pipelines. (default: `true`)
 * *logstash_connector_pipelines*: Definition of connector pipelines. See docs/connector-pipelines.md for details

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ logstash_no_pipelines: false
 #     source: https://github.com/widhalmt/shipper-logstash-pipeline.git
 logstash_elasticsearch_output: true
 logstash_beats_input: true
+logstash_beats_tls_encryptkey: true
 logstash_connector: true
 
 # logstash security

--- a/tasks/logstash-security.yml
+++ b/tasks/logstash-security.yml
@@ -83,7 +83,7 @@
 - name: Fetch certificate from ca host to master
   fetch:
     src: "{{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.zip"
-    dest: "/tmp/{{ ansible_hostname }}.zip"
+    dest: "/tmp/{{ ansible_hostname }}-ls.zip"
     flat: yes
   delegate_to: "{{ elasticsearch_ca }}"
   tags:
@@ -91,7 +91,7 @@
 
 - name: Copy the certificate to actual node
   unarchive:
-    src: "/tmp/{{ ansible_hostname }}.zip"
+    src: "/tmp/{{ ansible_hostname }}-ls.zip"
     dest: "{{ logstash_certs_dir }}/"
     owner: root
     group: logstash

--- a/tasks/logstash-security.yml
+++ b/tasks/logstash-security.yml
@@ -25,19 +25,19 @@
     --ca-pass {{ elastic_ca_pass }}
     --name {{ ansible_hostname }}
     --ip {{ ansible_default_ipv4.address }}
-    --dns {{ ansible_hostname }},{{ ansible_fqdn }}
-    --pass "{{ logstash_tls_key_passphrase }}"
-    --out {{ elastic_ca_dir }}/{{ ansible_hostname }}.p12
+    --dns {{ ansible_hostname }},{{ ansible_fqdn }},{{ inventory_hostname }}
+    --pass {{ logstash_tls_key_passphrase }}
+    --out {{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.p12
   delegate_to: "{{ elasticsearch_ca }}"
   args:
-    creates: "{{ elastic_ca_dir }}/{{ ansible_hostname }}.p12"
+    creates: "{{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.p12"
   tags:
     - certificates
 
 - name: Fetch certificate from ca host to master
   fetch:
-    src: "{{ elastic_ca_dir }}/{{ ansible_hostname }}.p12"
-    dest: "/tmp/{{ ansible_hostname }}.p12"
+    src: "{{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.p12"
+    dest: "/tmp/{{ ansible_hostname }}-ls.p12"
     flat: yes
   delegate_to: "{{ elasticsearch_ca }}"
   tags:
@@ -55,7 +55,7 @@
 
 - name: Copy the certificate to actual node
   copy:
-    src: "/tmp/{{ ansible_hostname }}.p12"
+    src: "/tmp/{{ ansible_hostname }}-ls.p12"
     dest: "{{ logstash_certs_dir }}/keystore.pfx"
     owner: root
     group: logstash
@@ -72,17 +72,17 @@
     --ca-pass {{ elastic_ca_pass }}
     --name {{ ansible_hostname }}
     --ip {{ ansible_default_ipv4.address }}
-    --dns {{ ansible_hostname }},{{ ansible_fqdn }}
+    --dns {{ ansible_hostname }},{{ ansible_fqdn }},{{ inventory_hostname }}
     --pass {{ logstash_tls_key_passphrase }}
     --pem
-    --out {{ elastic_ca_dir }}/{{ ansible_hostname }}.zip
+    --out {{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.zip
   delegate_to: "{{ elasticsearch_ca }}"
   args:
-    creates: "{{ elastic_ca_dir }}/{{ ansible_hostname }}.zip"
+    creates: "{{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.zip"
 
 - name: Fetch certificate from ca host to master
   fetch:
-    src: "{{ elastic_ca_dir }}/{{ ansible_hostname }}.zip"
+    src: "{{ elastic_ca_dir }}/{{ ansible_hostname }}-ls.zip"
     dest: "/tmp/{{ ansible_hostname }}.zip"
     flat: yes
   delegate_to: "{{ elasticsearch_ca }}"
@@ -135,6 +135,19 @@
     -passout pass:{{ logstash_tls_key_passphrase }}
   args:
     creates: "{{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key"
+  when: logstash_beats_tls_encryptkey | bool
+
+- name: Create unencrypted Logstash compatible key
+  command: >
+    openssl pkcs8
+    -in {{ logstash_certs_dir }}/{{ inventory_hostname }}.key
+    -topk8
+    -passin pass:{{ logstash_tls_key_passphrase }}
+    -out {{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key
+    -nocrypt
+  args:
+    creates: "{{ logstash_certs_dir }}/{{ inventory_hostname }}-pkcs8.key"
+  when: not logstash_beats_tls_encryptkey | bool
 
 - name: Set permissions on Logstash key
   file:

--- a/templates/beats-input.conf.j2
+++ b/templates/beats-input.conf.j2
@@ -8,7 +8,9 @@ input {
     ssl_verify_mode => force_peer
     ssl_certificate_authorities => ["{{ logstash_certs_dir }}/ca.crt"]
     ssl_peer_metadata => false
+{% if logstash_beats_tls_encryptkey | bool %}
     ssl_key_passphrase => "{{ logstash_tls_key_passphrase }}"
+{% endif %}
 {% endif %}
 
   }


### PR DESCRIPTION
fixes #135

It looks like there are still some hosts where pkcs8 keys for Logstash
Beats input must not be encrypted. The strange thing about it is that it
works on some systems (CentOS 7) and on some it doesn't (so far Ubuntu
20.04). I tried recreating the keys and some other ways but the Ubuntu host didn't like encrypted keys at all. So here's a workaround.

Several other potential issues came up and were fixed, namely:

* There's now a variable to disable encryption of the key used for the
  Beats input in Logstash
* Logstash certificates created with `certutil` get now a suffix to
  their name. This helps when you have different passwords for
  keys in different tools. Otherwise they overwrite each other and you
  don't know which file has which passphrase
* If your host is not dns resolvable you might end up with certificates for the wrong hostname so there's now `inventory_hostname` used as well